### PR TITLE
修复文件读取问题，使用 path 模块获取绝对路径

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var moment = require('moment');
+var path = require('path');
 var Days = require('./days');
 
 var ChineseHolidays = {
@@ -59,9 +60,10 @@ var ChineseHolidays = {
     return moment(date).format('YYYY-MM-DD');
   },
   _loadEvents: function() {
-    var files = fs.readdirSync('./data');
+    var dataDirectory = path.resolve(__dirname, './data');
+    var files = fs.readdirSync(dataDirectory);
     var eventsOfYears = files.map(function(file) {
-      var elements = JSON.parse(fs.readFileSync('./data/' + file, 'utf8'));
+      var elements = JSON.parse(fs.readFileSync(path.resolve(dataDirectory, file), 'utf8'));
       return elements.map(function(ele) {
         return new Days(ele.name, ele.range, ele.type);
       })


### PR DESCRIPTION
这个模块在被使用时会报`./data`目录不存在错误

这是因为读取目录时使用了相对路径，所以只有当程序是在这个模块根目录下执行时才能找到`./data`目录。

我把相对路径修改成了绝对路径。